### PR TITLE
Add log-level option

### DIFF
--- a/src/more_click/options.py
+++ b/src/more_click/options.py
@@ -60,7 +60,7 @@ force_option = click.option('-f', '--force', is_flag=True)
 debug_option = click.option('--debug', is_flag=True)
 
 # sorted level names, by log-level
-_level_names = [k for k, _ in sorted(logging._nameToLevel.items(), key=itemgetter(1))]
+_level_names = sorted(logging._nameToLevel, key=logging._nameToLevel.get)
 
 def log_level_option(default: Union[str, int] = logging.INFO):
     """Create a click option to select a log-level by name."""

--- a/src/more_click/options.py
+++ b/src/more_click/options.py
@@ -5,6 +5,7 @@
 import logging
 import multiprocessing
 from typing import Union
+from operator import itemgetter
 
 import click
 
@@ -58,6 +59,13 @@ workers_option = click.option(
 force_option = click.option('-f', '--force', is_flag=True)
 debug_option = click.option('--debug', is_flag=True)
 
-_level_names = sorted(logging._nameToLevel.keys())
+# sorted level names, by log-level
+_level_names = [k for k, _ in sorted(logging._nameToLevel.items(), key=itemgetter(1))]
+
 def log_level_option(default: Union[str, int] = logging.INFO):
+    """Create a click option to select a log-level by name."""
+    # normalize default to be a string
+    if isinstance(default, int):
+        default = logging.getLevelName(level=default)
+
     return click.option("-ll", "--log-level", type=click.Choice(choices=_level_names, case_sensitive=False), default=default)

--- a/src/more_click/options.py
+++ b/src/more_click/options.py
@@ -4,6 +4,7 @@
 
 import logging
 import multiprocessing
+from typing import Union
 
 import click
 
@@ -15,6 +16,7 @@ __all__ = [
     'workers_option',
     'force_option',
     'debug_option',
+    'log_level_option',
 ]
 
 LOG_FMT = '%(asctime)s %(levelname)-8s %(message)s'
@@ -55,3 +57,7 @@ workers_option = click.option(
 )
 force_option = click.option('-f', '--force', is_flag=True)
 debug_option = click.option('--debug', is_flag=True)
+
+_level_names = sorted(logging._nameToLevel.keys())
+def log_level_option(default: Union[str, int] = logging.INFO):
+    return click.option("-ll", "--log-level", type=click.Choice(choices=_level_names, case_sensitive=False), default=default)


### PR DESCRIPTION
This PR adds a log-level option, which allows selecting the name of a log-level, and allows configuration of a default value. 

It also makes use of `click.Choice` to give useful hints about the allowed values. I decided for the level names since they are more intuitive to select as a user than choosing the corresponding integer constants.

The following MWE shows how to use it with a non-default `default` choice.
```python
import logging

import click
import more_click

@click.command()
@more_click.log_level_option(default=logging.WARNING)
def main(
    log_level: str,
):
    logging.basicConfig(level=log_level)
    # do something
```